### PR TITLE
post_proc: remove unnecessary command size check

### DIFF
--- a/post_proc/bundle.c
+++ b/post_proc/bundle.c
@@ -660,8 +660,6 @@ int effect_command(effect_handle_t self, uint32_t cmdCode, uint32_t cmdSize,
         } break;
     case EFFECT_CMD_SET_PARAM: {
         if (pCmdData == NULL ||
-            cmdSize > (int)(sizeof(effect_param_t) + sizeof(uint32_t) +
-                            sizeof(uint32_t)) ||
             cmdSize < (int)(sizeof(effect_param_t) + sizeof(uint32_t) +
                             sizeof(uint16_t)) ||
             pReplyData == NULL || *replySize != sizeof(int32_t)) {


### PR DESCRIPTION
Up bound check for command size of EFFECT_CMD_SET_PARAM is not
applicable for DSP effect bundle. Remove the check to avoid parameter
not taking effect.

Change-Id: I7e8f73377699f11bdc1f62a05f6bea03c9c24151
CRs-Fixed: 816053